### PR TITLE
Fix: Enforce wall collision detection in GridWorldEnv.step()

### DIFF
--- a/gridworld/utils/gridworld.py
+++ b/gridworld/utils/gridworld.py
@@ -339,7 +339,12 @@ class GridWorldEnv(gym.Env):
 
     def step(self, action):
         move = np.round(np.clip(action, -1, 1)).astype(int)
-        self.pos = np.clip(self.pos + move, 0, self.grid_size - 1)
+
+        new_pos = np.clip(self.pos + move, 0, self.grid_size - 1)
+        if tuple(new_pos) in self.config.wall_cells:
+            new_pos = self.pos  # Stay in current position
+    
+        self.pos = new_pos
         grid_pos = self.pos
         
         r = float(self.reward_map[grid_pos[1], grid_pos[0]])


### PR DESCRIPTION
## Fix: Enforce wall collision detection in GridWorldEnv.step()

### Problem
The `GridWorldEnv.step()` method was not enforcing wall collisions. While `wall_cells` were defined in environment configs, agents could move through them during training, leading to policies that ignore walls.

### Solution  
- Added wall collision detection in `step()`

### Testing
- Verified walls now block agent movement in `cshape` environment
- Tested that agents can no longer pass through walls during rollouts

<div style="display: flex; gap: 20px;">
  <img src="https://github.com/user-attachments/assets/d814ce0d-32c4-49a4-8718-699d12a49802" 
       alt="FPO" width="350" />
  <img src="https://github.com/user-attachments/assets/e0492436-0a83-47a1-9bd1-41d95c9596cf" 
       alt="PPO" width="350" />
</div>
